### PR TITLE
feat: bulk move, import/export csv

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -164,6 +164,18 @@ if (checks()) {
 		<div class="row">
 			<div class="col-xs-8">
 				<label>
+					Select Range
+					<input id="__PSZY_RANGE__" type="text" placeholder="0-10,14-18,20,25">
+				</label>
+				<input id="__PSZY_SELECTRANGE__" type="button" value="Select" class="btn btn-primary">
+				<input id="__PSZY_DESELECTRANGE__" type="button" value="Deselect" class="btn btn-inverse">
+			</div>
+			<div class="col-xs-8">
+				<input id="__PSZY_DESELECTALL__" type="button" value="Deselect All" class="btn btn-inverse">
+				<span id="__PSZY_SELECTEDCOUNT__">0</span> selected
+			</div>
+			<div class="col-xs-8">
+				<label>
 					Move selected to (preference#)
 					<input id="__PSZY_PREFNO__" type="number" value="1" min="1">
 				</label>
@@ -232,6 +244,15 @@ if (checks()) {
 				}).then(response => response.json())
 				.then(data => JSON.parse(data.d)[0])
 				.then(data => window.open(`StationproblemBankDetails.aspx?CompanyId=${data.CompanyId}&StationId=${data.StationId}&BatchIdFor=${data.BatchIdFor}&PSTypeFor=${data.PSTypeFor}`, "_blank"))
+				break
+			case '__PSZY_SELECTRANGE__':
+				selectRange()
+				break
+			case '__PSZY_DESELECTRANGE__':
+				deselectRange()
+				break
+			case '__PSZY_DESELECTALL__':
+				deselectAll()
 				break
 			case '__PSZY_MOVESELECTED__':
 				moveSelected()
@@ -310,12 +331,60 @@ if (checks()) {
 		if (node.matches('input, a, button')) return
 		// else (de)select the item
 		node.closest('#sortable_nav > li')?.classList.toggle('selected')
+		updateSelectedCount()
 	}
 
 	function deselectAll() {
 		$('#sortable_nav').querySelectorAll('li.selected').forEach(node => node.classList.remove('selected'))
+		updateSelectedCount()
 	}
 
+	function getRange() {
+		const ranges = $('#__PSZY_RANGE__').value.split(',')
+		const indices = []
+		ranges.forEach(r => {
+			r = r.trim()
+			// matches numbers
+			// insensitive to whitespace around number
+			const singleNum = r.match(/^(\d+)$/m)
+			if (singleNum !== null) {
+				indices.push(parseInt(singleNum[1]))
+				return
+			}
+			// matches: 10-22
+			// insensitive to whitespace around number
+			const numRange = r.match(/^(\d+)\W*-\W*(\d+)$/m)
+			if (numRange !== null) {
+				const min = parseInt(numRange[1])
+				const max = parseInt(numRange[2])
+				for (let i = min; i <= max; i++) {
+					indices.push(i)
+				}
+				return
+			}
+		})
+		return indices
+	}
+
+	function selectRange() {
+		const list = $('#sortable_nav > li')
+		getRange().forEach(i => {
+			list[i-1].classList.add('selected')
+		})
+		updateSelectedCount()
+	}
+
+	function deselectRange() {
+		const list = $('#sortable_nav > li')
+		getRange().forEach(i => {
+			list[i-1].classList.remove('selected')
+		})
+		updateSelectedCount()
+	}
+	function updateSelectedCount() {
+		const count = $('#sortable_nav').querySelectorAll('li.selected').length
+		$('#__PSZY_SELECTEDCOUNT__').innerText = count.toString()
+	}
 
 	function moveup(node) {
 		const prevNode = node.previousSibling

--- a/src/content.js
+++ b/src/content.js
@@ -171,6 +171,14 @@ if (checks()) {
 				<input id="__PSZY_DESELECTRANGE__" type="button" value="Deselect" class="btn btn-inverse">
 			</div>
 			<div class="col-xs-8">
+				<label>
+					Select Pattern
+					<input id="__PSZY_PATTERN__" type="text" placeholder="IT|Bengaluru (regex)">
+				</label>
+				<input id="__PSZY_SELECTPATTERN__" type="button" value="Select" class="btn btn-primary">
+				<input id="__PSZY_DESELECTPATTERN__" type="button" value="Deselect" class="btn btn-inverse">
+			</div>
+			<div class="col-xs-8">
 				<input id="__PSZY_DESELECTALL__" type="button" value="Deselect All" class="btn btn-inverse">
 				<span id="__PSZY_SELECTEDCOUNT__">0</span> selected
 			</div>
@@ -250,6 +258,12 @@ if (checks()) {
 				break
 			case '__PSZY_DESELECTRANGE__':
 				deselectRange()
+				break
+			case '__PSZY_SELECTPATTERN__':
+				selectPattern()
+				break
+			case '__PSZY_DESELECTPATTERN__':
+				deselectPattern()
 				break
 			case '__PSZY_DESELECTALL__':
 				deselectAll()
@@ -381,6 +395,36 @@ if (checks()) {
 		})
 		updateSelectedCount()
 	}
+
+	function getPattern() {
+		const pattern = $('#__PSZY_PATTERN__').value
+		return new RegExp(pattern, 'im')
+	}
+
+	function selectPattern() {
+		const list = $('#sortable_nav > li')
+		const re = getPattern()
+		list.forEach(n => {
+			const text = n.querySelector('span.spanclass').innerText
+			if (re.test(text)) {
+				n.classList.add('selected')
+			}
+		})
+		updateSelectedCount()
+	}
+
+	function deselectPattern() {
+		const list = $('#sortable_nav > li')
+		const re = getPattern()
+		list.forEach(n => {
+			const text = n.querySelector('span.spanclass').innerText
+			if (re.test(text)) {
+				n.classList.remove('selected')
+			}
+		})
+		updateSelectedCount()
+	}
+
 	function updateSelectedCount() {
 		const count = $('#sortable_nav').querySelectorAll('li.selected').length
 		$('#__PSZY_SELECTEDCOUNT__').innerText = count.toString()

--- a/src/content.js
+++ b/src/content.js
@@ -41,19 +41,6 @@ if (checks()) {
 			order: 4;
 			gap: 10px;
         }
-        div#__PSZY_CONTROLS__>div {
-            font-size: 12px;
-            background: #418aca;
-            color: white;
-            padding: 8px;
-            width: 25px;
-            height: 25px;
-            display: flex;
-            justify-content: center;
-            border-radius: 50%;
-            align-items: center;
-            cursor: pointer;
-        }
 
 		ul#sortable_nav>li {
 			display: flex;
@@ -83,8 +70,8 @@ if (checks()) {
 			order: 5;
 			float: none;
 			margin: 0;
-			width: 15px;
-			height: 15px;
+			width: 24px;
+			height: 24px;
 		}
 
         ul#sortable_nav>li:first-child div#__PSZY_CONTROLS__ #__PSZY_MOVEUP__ {
@@ -107,25 +94,10 @@ if (checks()) {
 			display: none;
 		}
 
-        div#__PSZY_CONTROLS__ div#__PSZY_SWAP__ {
-            border-radius: 10px;
-            width: auto;
-        }
-
-        div#__PSZY_CONTROLS__ div#__PSZY_MOVETO__ {
-            border-radius: 10px;
-            width: auto;
-        }
-
-        div#__PSZY_CONTROLS__ div#__PSZY_MOVERANGE__ {
-            border-radius: 10px;
-            width: auto;
-        }
-
         div#__PSZY_CONTROLS__ svg {
 			pointer-events: none;
-            width: 15px;
-            height: 15px;
+            width: 12px;
+            height: 12px;
         }
 
         @keyframes bg {
@@ -201,13 +173,13 @@ if (checks()) {
 	const controls = `
 	<div class="spacer">&nbsp;</div>
     <div id="__PSZY_CONTROLS__">
-        <div id="__PSZY_MOVEUP__" title="Move 1 up">${PSZYIcons.moveUp}</div>
-        <div id="__PSZY_MOVEDOWN__" title="Move 1 down">${PSZYIcons.moveDown}</div>
-        <div id="__PSZY_TOP__" title="Send to top">${PSZYIcons.sendToTop}</div>
-        <div id="__PSZY_BOTTOM__" title="Send to bottom">${PSZYIcons.sendToBottom}</div>
-        <div id="__PSZY_SWAP__" title="Swap">Swap</div>
-        <div id="__PSZY_MOVETO__" title="Move to">MoveTo</div>
-        <div id="__PSZY_PBANK__" title="open problem bank">${PSZYIcons.info}</div>
+        <div id="__PSZY_MOVEUP__" class="btn btn-primary" title="Move 1 up">${PSZYIcons.moveUp}</div>
+        <div id="__PSZY_MOVEDOWN__" class="btn btn-primary" title="Move 1 down">${PSZYIcons.moveDown}</div>
+        <div id="__PSZY_TOP__" class="btn btn-primary" title="Send to top">${PSZYIcons.sendToTop}</div>
+        <div id="__PSZY_BOTTOM__" class="btn btn-primary" title="Send to bottom">${PSZYIcons.sendToBottom}</div>
+        <div id="__PSZY_SWAP__" class="btn btn-primary" title="Swap">Swap</div>
+        <div id="__PSZY_MOVETO__" class="btn btn-primary" title="Move to">MoveTo</div>
+        <div id="__PSZY_PBANK__" class="btn btn-inverse" title="open problem bank">${PSZYIcons.info}</div>
     </div>`
 
 	const lis = $('#sortable_nav > li')

--- a/src/content.js
+++ b/src/content.js
@@ -29,7 +29,8 @@ if (checks()) {
 		sendToBottom: '<svg aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path fill="currentColor" d="M360 480H24c-13.3 0-24-10.7-24-24v-24c0-13.3 10.7-24 24-24h336c13.3 0 24 10.7 24 24v24c0 13.3-10.7 24-24 24zM128 56v136H40.3c-17.8 0-26.7 21.5-14.1 34.1l152.2 152.2c7.5 7.5 19.8 7.5 27.3 0l152.2-152.2c12.6-12.6 3.7-34.1-14.1-34.1H256V56c0-13.3-10.7-24-24-24h-80c-13.3 0-24 10.7-24 24z"></path></svg>',
 		moveUp: '<svg aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512" ><path fill="currentColor" d="M34.9 289.5l-22.2-22.2c-9.4-9.4-9.4-24.6 0-33.9L207 39c9.4-9.4 24.6-9.4 33.9 0l194.3 194.3c9.4 9.4 9.4 24.6 0 33.9L413 289.4c-9.5 9.5-25 9.3-34.3-.4L264 168.6V456c0 13.3-10.7 24-24 24h-32c-13.3 0-24-10.7-24-24V168.6L69.2 289.1c-9.3 9.8-24.8 10-34.3.4z"></path></svg>',
 		moveDown: '<svg aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M413.1 222.5l22.2 22.2c9.4 9.4 9.4 24.6 0 33.9L241 473c-9.4 9.4-24.6 9.4-33.9 0L12.7 278.6c-9.4-9.4-9.4-24.6 0-33.9l22.2-22.2c9.5-9.5 25-9.3 34.3.4L184 343.4V56c0-13.3 10.7-24 24-24h32c13.3 0 24 10.7 24 24v287.4l114.8-120.5c9.3-9.8 24.8-10 34.3-.4z"></path></svg>',
-		info: '<svg aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 512"><path fill="currentColor" d="M20 424.229h20V279.771H20c-11.046 0-20-8.954-20-20V212c0-11.046 8.954-20 20-20h112c11.046 0 20 8.954 20 20v212.229h20c11.046 0 20 8.954 20 20V492c0 11.046-8.954 20-20 20H20c-11.046 0-20-8.954-20-20v-47.771c0-11.046 8.954-20 20-20zM96 0C56.235 0 24 32.235 24 72s32.235 72 72 72 72-32.235 72-72S135.764 0 96 0z"></path></svg>'
+		info: '<svg aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 512"><path fill="currentColor" d="M20 424.229h20V279.771H20c-11.046 0-20-8.954-20-20V212c0-11.046 8.954-20 20-20h112c11.046 0 20 8.954 20 20v212.229h20c11.046 0 20 8.954 20 20V492c0 11.046-8.954 20-20 20H20c-11.046 0-20-8.954-20-20v-47.771c0-11.046 8.954-20 20-20zM96 0C56.235 0 24 32.235 24 72s32.235 72 72 72 72-32.235 72-72S135.764 0 96 0z"></path></svg>',
+		scrollToTop: '<svg aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M201.4 137.4c12.5-12.5 32.8-12.5 45.3 0l160 160c12.5 12.5 12.5 32.8 0 45.3s-32.8 12.5-45.3 0L224 205.3 86.6 342.6c-12.5 12.5-32.8 12.5-45.3 0s-12.5-32.8 0-45.3l160-160z"></path></svg>',
 	}
 
 	const styles = `
@@ -102,7 +103,8 @@ if (checks()) {
 			display: none;
 		}
 
-        div#__PSZY_CONTROLS__ svg {
+        #__PSZY_CONTROLS__ svg,
+		#__PSZY_GLOBAL_CONTROLS__ svg {
 			pointer-events: none;
             width: 12px;
             height: 12px;
@@ -193,6 +195,9 @@ if (checks()) {
 				<input id="__PSZY_MOVESELECTEDTOP__" type="button" value="Top" class="btn btn-inverse">
 				<input id="__PSZY_MOVESELECTEDBOTTOM__" type="button" value="Bottom" class="btn btn-inverse">
 			</div>
+		</div>
+		<div>
+			<div id="__PSZY_SCROLLTOTOP__" class="btn btn-inverse" style="position:fixed;right:20px;bottom:20px">${PSZYIcons.scrollToTop}</div>
 		</div>
 	</div>`
 
@@ -286,6 +291,13 @@ if (checks()) {
 				break
 			case '__PSZY_MOVESELECTEDBOTTOM__':
 				moveselectedbottom()
+				break
+			case '__PSZY_SCROLLTOTOP__':
+				window.scrollTo({
+					top: 0,
+					left: 0,
+					behavior: 'smooth',
+				})
 				break
 			default:
 				selectNode(e.target)

--- a/src/content.js
+++ b/src/content.js
@@ -33,13 +33,18 @@ if (checks()) {
 	}
 
 	const styles = `
-        div#__PSZY_CONTROLS__ {
+		#__PSZY_GLOBAL_CONTROLS__ .row {
+			margin: 12px auto;
+		}
+
+        #__PSZY_CONTROLS__ {
 			flex: 0 0 auto;
             display: flex;
             justify-content: flex-end;
             align-items: center;
 			order: 4;
 			gap: 10px;
+			height: 24px;
         }
 
 		ul#sortable_nav>li {
@@ -60,8 +65,11 @@ if (checks()) {
 			order: 2;
 		}
 
-		ul#sortable_nav>li .spacer {
+		.spacer {
 			flex: 1 1 auto;
+		}
+
+		ul#sortable_nav>li .spacer {
 			order: 3;
 		}
 
@@ -139,26 +147,38 @@ if (checks()) {
 					Select Range
 					<input id="__PSZY_RANGE__" type="text" placeholder="0-10,14-18,20,25">
 				</label>
+			</div>
+			<div class="col-xs-8">
 				<input id="__PSZY_SELECTRANGE__" type="button" value="Select" class="btn btn-primary">
 				<input id="__PSZY_DESELECTRANGE__" type="button" value="Deselect" class="btn btn-inverse">
 			</div>
+		</div>
+		<div class="row">
 			<div class="col-xs-8">
 				<label>
 					Select Pattern
 					<input id="__PSZY_PATTERN__" type="text" placeholder="IT|Bengaluru (regex)">
 				</label>
+			</div>
+			<div class="col-xs-8">
 				<input id="__PSZY_SELECTPATTERN__" type="button" value="Select" class="btn btn-primary">
 				<input id="__PSZY_DESELECTPATTERN__" type="button" value="Deselect" class="btn btn-inverse">
 			</div>
+		</div>
+		<div class="row">
 			<div class="col-xs-8">
 				<input id="__PSZY_DESELECTALL__" type="button" value="Deselect All" class="btn btn-inverse">
 				<span id="__PSZY_SELECTEDCOUNT__">0</span> selected
 			</div>
+		</div>
+		<div class="row">
 			<div class="col-xs-8">
 				<label>
 					Move selected to (preference#)
 					<input id="__PSZY_PREFNO__" type="number" value="1" min="1">
 				</label>
+			</div>
+			<div class="col-xs-8">
 				<input id="__PSZY_MOVESELECTED__" type="button" value="Move" class="btn btn-primary">
 				<input id="__PSZY_MOVESELECTEDTOP__" type="button" value="Top" class="btn btn-inverse">
 				<input id="__PSZY_MOVESELECTEDBOTTOM__" type="button" value="Bottom" class="btn btn-inverse">

--- a/src/content.js
+++ b/src/content.js
@@ -316,7 +316,8 @@ if (checks()) {
 	function moveSelected() {
 		const selectedItems = Array.from($('#sortable_nav').querySelectorAll('li.selected'))
 		const targetPref = parseInt($('#__PSZY_PREFNO__').value, 10)
-		const list = $('#sortable_nav li')
+		const listContainer = $('#sortable_nav')
+		let list = $('#sortable_nav li')
 		// input validation
 		if (selectedItems.length == 0) {
 			return alert('Select at least one station')
@@ -328,13 +329,20 @@ if (checks()) {
 			return alert('Not enough stations. Try a smaller number')
 		}
 		// move
-		// convert to 0 based index and correct for rank gap created
-		selectedRanks = selectedItems.map(n => n.querySelector('#spnRank').innerText)
-		gap = selectedRanks.filter(r => r <= targetPref).length
-		const targetNode = list[targetPref - 1 + gap]
 		selectedItems.forEach(node => {
-			node.parentNode.insertBefore(node, targetNode)
+			listContainer.removeChild(node)
 		})
+		list = $('#sortable_nav li')
+		if (targetPref < list.length) {
+			let targetNode = list[targetPref - 1] // zero based index
+			selectedItems.forEach(node => {
+				listContainer.insertBefore(node, targetNode)
+			})
+		} else {
+			selectedItems.forEach(node => {
+				listContainer.appendChild(node)
+			})
+		}
 		correctRanks()
 		glow(...selectedItems)
 		deselectAll()


### PR DESCRIPTION
added bulk move feature from pr #8:

- select multiple rows by clicking, range, or pattern 3546f56...e74c20f. fixes #4
- move ranges to anywhere e74c20f...c19bb71
- refactor all move* functions to use the same move logic c19bb71...dd116dd (bad diff). fixes #4

  > As for the move range alerts I agree that can be worked on to make it more intuitive(maybe take both inputs using one prompt and debugging them together), given time I was also thinking of having a checkbox in each li element and then providng the club and position at index feature. later versions can have it possibly.

style:

- use class tokens from top document, layout improvements dd116dd...284e09d

other:

- import/export to csv 284e09d...d42921d



![image](https://user-images.githubusercontent.com/58023300/200551520-8ce4c01f-d70f-470f-b3e3-bc7c13cf4835.png)

